### PR TITLE
Add Makefile cleanup target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,10 @@ logs:
 shell:
 	$(COMPOSE) exec app sh
 
-.PHONY: build up stop down restart logs shell
+fclean:
+	$(COMPOSE) down -v
+	docker ps -a --filter "name=agent_" -q | xargs -r docker rm -f
+	docker volume ls --filter "name=agent_" -q | xargs -r docker volume rm
+	docker network ls --filter "name=agent_" -q | xargs -r docker network rm
+
+.PHONY: build up stop down restart logs shell fclean


### PR DESCRIPTION
## Summary
- add `fclean` target to remove all containers, volumes and networks prefixed with `agent_`

## Testing
- `make fclean` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841e6dbbe2c8325bf1f9f3ba543575b