### PR TITLE
Fix container setup and Laravel startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./laravel:/var/www
     command: ./start.sh
     ports:
-      - "8123:8000"
+      - "8000:8000"
       - "5173:5173"
     networks:
       - appnet

--- a/laravel/start.sh
+++ b/laravel/start.sh
@@ -3,6 +3,11 @@ set -e
 
 cd /var/www
 
+if [ ! -f .env ]; then
+    cp .env.example .env
+    php artisan key:generate
+fi
+
 if [ ! -d vendor ]; then
     composer install --no-interaction
 fi


### PR DESCRIPTION
## Summary
- fix port mappings for the app container
- auto-create `.env` and generate APP_KEY when the container starts

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdadf5870832583cf398964a7106c