### PR TITLE
Use conf.d for Apache proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project sets up a development environment for a Laravel application with Vue and Vite.
 
-Use the provided `docker-compose` configuration to start all services. When the containers come up, composer dependencies will automatically be installed if missing, Vite will run in development mode with hot reloading, and `php artisan serve` will be started.
+Use the provided `docker-compose` configuration to start all services. When the containers come up, composer dependencies will automatically be installed if missing, Vite will run in development mode with hot reloading, and `php artisan serve` will be started. The Apache container is built from `httpd:alpine` and is configured to load files from `conf.d`, so `apache/proxy.conf` is mounted as `/usr/local/apache2/conf/conf.d/proxy.conf`.
 
 To start the environment:
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,0 +1,3 @@
+FROM httpd:alpine
+RUN echo '\nIncludeOptional conf.d/*.conf' >> /usr/local/apache2/conf/httpd.conf
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,12 @@ services:
       - db
   web:
     container_name: agent_web
-    image: httpd:alpine
+    build: ./apache
     ports:
       - "8123:80"
     volumes:
       - ./laravel:/var/www
-      - ./apache/proxy.conf:/usr/local/apache2/conf/httpd.conf:ro
+      - ./apache/proxy.conf:/usr/local/apache2/conf/conf.d/proxy.conf:ro
     networks:
       - appnet
     depends_on:


### PR DESCRIPTION
## Summary
- mount the proxy config into `conf.d`
- build a lightweight custom httpd image that loads `conf.d`
- document the new location for `proxy.conf`

## Testing
- `make up` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdd9d42648325af217b9858db55c4